### PR TITLE
Small fix in XHR for Firefox OS

### DIFF
--- a/karmacracy.js
+++ b/karmacracy.js
@@ -30,7 +30,7 @@ function Karmacracy(appkey, lang) {
 			params = {};
 		}
 
-		var xhr = XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP");
+		var xhr = XMLHttpRequest ? new XMLHttpRequest({mozSystem: true}) : new ActiveXObject("Microsoft.XMLHTTP");
 
 		var requestType = _getRequestType.call(this, method);
 		var url = _getUrl.call(this, method, params);


### PR DESCRIPTION
Just a little fix to make XHR requests work inside Firefox OS for requests without CORS enabled.

Only non minified file was modified so the others would need to be regenerated.
